### PR TITLE
update deprecated preset to modern one

### DIFF
--- a/default.py
+++ b/default.py
@@ -458,7 +458,7 @@ class LoungeRipper():
                     self.buildDestFileAndFolder()
 
                 # self.encoder = '"%s" -i "%s" -o "%s" -f mkv -d slower -N %s --native-dub -m -Z "High Profile" -s 1 %s %s %s %s %s 2>&1' % \
-                self.encoder = '"%s" -i "%s" -o "%s" -f mkv --decomb fast -N %s --native-dub -m -Z "High Profile" -s 1 %s %s %s %s %s 2>&1' % \
+                self.encoder = '"%s" -i "%s" -o "%s" -f mkv --decomb fast -N %s --native-dub -m -Z "H.264 MKV 1080p30" -s 1 %s %s %s %s %s 2>&1' % \
                                (self.encoder_executable,
                                os.path.join(self.tempfolder, self.src),
                                os.path.join(self.destfolder, self.destfile),


### PR DESCRIPTION
latest handbrake has deprecated a number of presets, including "High Profile".

here is their current documentation: 
https://handbrake.fr/docs/en/latest/technical/official-presets.html

this PR just selects one that works well for wanting high quality and sticking with mkv container. not sure if you wanted this, but might be useful for others that find your repo.

thanks for making this add-on!